### PR TITLE
Using values set in pom.xml

### DIFF
--- a/cookiecutters/portlet/{{ cookiecutter.artifact_id }}/src/main/webapp/WEB-INF/portlet.xml
+++ b/cookiecutters/portlet/{{ cookiecutter.artifact_id }}/src/main/webapp/WEB-INF/portlet.xml
@@ -7,9 +7,9 @@
 	version="2.0">
 
 	<portlet>
-		<description>{{ cookiecutter.short_description }}</description>
+		<description>${project.description}</description>
 		<portlet-name>${project.artifactId}</portlet-name>
-		<display-name>{{ cookiecutter.display_name }}</display-name>
+		<display-name>${project.name}</display-name>
 
 		<portlet-class>com.vaadin.server.VaadinPortlet</portlet-class>
 
@@ -30,8 +30,8 @@
 
 
 		<portlet-info>
-			<title>{{ cookiecutter.display_name }}</title>
-			<short-title>{{ cookiecutter.short_description }}</short-title>
+			<title>${project.name}</title>
+			<short-title>${project.description}</short-title>
 			<keywords>Vaadin 7, QBiC, Big Data, Bioinformatics</keywords>
 		</portlet-info>
 

--- a/cookiecutters/portlet/{{ cookiecutter.artifact_id }}/src/main/webapp/WEB-INF/web.xml
+++ b/cookiecutters/portlet/{{ cookiecutter.artifact_id }}/src/main/webapp/WEB-INF/web.xml
@@ -10,7 +10,7 @@
   		<param-value>true</param-value>
 	</context-param>
 
-	<display-name>{{ cookiecutter.display_name }}</display-name>
+	<display-name>${project.name}</display-name>
 	<servlet>
 		<servlet-name>${project.artifactId}</servlet-name>
 		<servlet-class>com.vaadin.server.VaadinServlet</servlet-class>


### PR DESCRIPTION
Cookiecutter values should be used in the `pom.xml` only. The only cookiecutter variable that is not avaiable in the `pom.xml` is `cookiecutter.main_class_prefix`.