### PR TITLE
[FIX] Disable Integration tests on travis as default

### DIFF
--- a/common-files/{{ cookiecutter.artifact_id }}/.travis.yml
+++ b/common-files/{{ cookiecutter.artifact_id }}/.travis.yml
@@ -32,7 +32,7 @@ before_script: if [ "$VAADIN_CHARTS_LICENSE_CODE" != "" ]; then
                fi;
 
 # as agreed in our SOP, build everything (don't deploy, just try to 'mvn install' locally, which covers all phases)
-script: mvn --quiet --activate-profiles !development-build,!release-build --settings .travis.settings.xml clean cobertura:cobertura install
+script: mvn --quiet --activate-profiles !development-build,!release-build --settings .travis.settings.xml clean cobertura:cobertura install -DskipITs
 # upload code coverage report, generate maven site (javadocs, documentation, static code analysis, etc.)
 after_success: 
 - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Hey,

I don't think that integration tests should be run by default, especially, since most of our integration tests depend on openBIS and the likes.

Hence, I would disable Integration tests by default and document how to enable them on travis if required.

Edit: we should add the same to the deploy goal...