### PR TITLE
Fix vaadin version information in liferay-plugin-package.properties

### DIFF
--- a/cookiecutters/portlet/{{ cookiecutter.artifact_id }}/src/main/webapp/WEB-INF/liferay-plugin-package.properties
+++ b/cookiecutters/portlet/{{ cookiecutter.artifact_id }}/src/main/webapp/WEB-INF/liferay-plugin-package.properties
@@ -1,7 +1,7 @@
 name=${project.artifactId}
 module-group-id=life.qbic
 module-incremental-version=${project.version}
-tags=Vaadin 7, QBiC, Big Data, Bioinformatics
+tags=Vaadin 8, QBiC, Big Data, Bioinformatics
 short-description=${project.description}
 page-url=${project.url}
 author={{ cookiecutter.copyright_holder }}


### PR DESCRIPTION
Change tag Vaadin 7 to Vaadin 8
This is then incorporated into the portlet xml file.